### PR TITLE
Configurable ws lives

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "pusher-js",
-  "version": "8.0.0",
+  "name": "@goguardian/pusher-js",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "pusher-js",
-      "version": "8.0.0",
+      "name": "@goguardian/pusher-js",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "@types/express-serve-static-core": "4.17.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "pusher-js",
-  "version": "8.0.1",
+  "name": "@goguardian/pusher-js",
+  "version": "0.0.1",
   "description": "Pusher Channels JavaScript library for browsers, React Native, NodeJS and web workers",
   "main": "dist/node/pusher.js",
   "browser": "dist/web/pusher.js",

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -36,6 +36,7 @@ export interface Config {
   wsPath: string;
   wsPort: number;
   wssPort: number;
+  wsLives: number;
   userAuthenticator: UserAuthenticationHandler;
   channelAuthorizer: ChannelAuthorizationHandler;
 
@@ -64,6 +65,7 @@ export function getConfig(opts: Options, pusher): Config {
     wsPath: opts.wsPath || Defaults.wsPath,
     wsPort: opts.wsPort || Defaults.wsPort,
     wssPort: opts.wssPort || Defaults.wssPort,
+    wsLives: opts.wsLives === undefined ? Defaults.wsLives : opts.wsLives,
 
     enableStats: getEnableStatsConfig(opts),
     httpHost: getHttpHost(opts),

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -49,6 +49,7 @@ export interface Config {
   ignoreNullOrigin?: boolean;
   nacl?: nacl;
   timelineParams?: any;
+  reportDeathCallback?: (info: Object) => void;
 }
 
 // getConfig mainly sets the defaults for the options that are not provided
@@ -73,7 +74,8 @@ export function getConfig(opts: Options, pusher): Config {
     wsHost: getWebsocketHost(opts),
 
     userAuthenticator: buildUserAuthenticator(opts),
-    channelAuthorizer: buildChannelAuthorizer(opts, pusher)
+    channelAuthorizer: buildChannelAuthorizer(opts, pusher),
+    reportDeathCallback: opts.reportDeathCallback
   };
 
   if ('disabledTransports' in opts)

--- a/src/core/defaults.ts
+++ b/src/core/defaults.ts
@@ -10,6 +10,7 @@ export interface DefaultConfig {
   wsPort: number;
   wssPort: number;
   wsPath: string;
+  wsLives: number;
   httpHost: string;
   httpPort: number;
   httpsPort: number;
@@ -35,6 +36,7 @@ var Defaults: DefaultConfig = {
   wsPort: 80,
   wssPort: 443,
   wsPath: '',
+  wsLives: 2,
   // DEPRECATED: SockJS fallback parameters
   httpHost: 'sockjs.pusher.com',
   httpPort: 80,

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -43,6 +43,7 @@ export interface Options {
   wsPort?: number;
   wssPort?: number;
   wsLives?: number;
+  reportDeathCallback?: (info: Object) => void;
 }
 
 export function validateOptions(options) {

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -42,6 +42,7 @@ export interface Options {
   wsPath?: string;
   wsPort?: number;
   wssPort?: number;
+  wsLives?: number;
 }
 
 export function validateOptions(options) {

--- a/src/core/transports/assistant_to_the_transport_manager.ts
+++ b/src/core/transports/assistant_to_the_transport_manager.ts
@@ -75,12 +75,19 @@ export default class AssistantToTheTransportManager {
 
       if (closeEvent.code === 1002 || closeEvent.code === 1003) {
         // we don't want to use transports not obeying the protocol
-        this.manager.reportDeath();
+        this.manager.reportDeath({
+          reason: 'close code',
+          close_code: closeEvent.code
+        });
       } else if (!closeEvent.wasClean && openTimestamp) {
         // report deaths only for short-living transport
         var lifespan = Util.now() - openTimestamp;
         if (lifespan < 2 * this.maxPingDelay) {
-          this.manager.reportDeath();
+          this.manager.reportDeath({
+            reason: 'closed uncleanly',
+            close_code: closeEvent.code,
+            lifespan
+          });
           this.pingDelay = Math.max(lifespan / 2, this.minPingDelay);
         }
       }

--- a/src/core/transports/transport_manager.ts
+++ b/src/core/transports/transport_manager.ts
@@ -5,6 +5,8 @@ import Factory from '../utils/factory';
 
 export interface TransportManagerOptions extends PingDelayOptions {
   lives?: number;
+  transportType?: string;
+  reportDeathCallback?: (info: Object) => void;
 }
 
 /** Keeps track of the number of lives left for a transport.
@@ -19,6 +21,7 @@ export interface TransportManagerOptions extends PingDelayOptions {
 export default class TransportManager {
   options: TransportManagerOptions;
   livesLeft: number;
+  reportDeathCallback?: (info: Object) => void;
 
   constructor(options: TransportManagerOptions) {
     this.options = options || {};
@@ -46,7 +49,15 @@ export default class TransportManager {
   }
 
   /** Takes one life from the transport. */
-  reportDeath() {
+  reportDeath(info: Object = {}) {
     this.livesLeft -= 1;
+
+    if (typeof this.options.reportDeathCallback === 'function') {
+      this.options.reportDeathCallback({
+        ...info,
+        transport_type: this.options.transportType || 'unknown',
+        lives_left: this.livesLeft
+      });
+    }
   }
 }

--- a/src/runtimes/isomorphic/default_strategy.ts
+++ b/src/runtimes/isomorphic/default_strategy.ts
@@ -66,7 +66,7 @@ var getDefaultStrategy = function(
   };
 
   var ws_manager = new TransportManager({
-    lives: 2,
+    lives: config.wsLives,
     minPingDelay: 10000,
     maxPingDelay: config.activityTimeout
   });

--- a/src/runtimes/isomorphic/default_strategy.ts
+++ b/src/runtimes/isomorphic/default_strategy.ts
@@ -66,14 +66,18 @@ var getDefaultStrategy = function(
   };
 
   var ws_manager = new TransportManager({
+    transportType: 'ws',
     lives: config.wsLives,
     minPingDelay: 10000,
-    maxPingDelay: config.activityTimeout
+    maxPingDelay: config.activityTimeout,
+    reportDeathCallback: config.reportDeathCallback
   });
   var streaming_manager = new TransportManager({
+    transportType: 'streaming',
     lives: 2,
     minPingDelay: 10000,
-    maxPingDelay: config.activityTimeout
+    maxPingDelay: config.activityTimeout,
+    reportDeathCallback: config.reportDeathCallback
   });
 
   var ws_transport = defineTransportStrategy(

--- a/src/runtimes/web/default_strategy.ts
+++ b/src/runtimes/web/default_strategy.ts
@@ -67,14 +67,18 @@ var getDefaultStrategy = function(
   };
 
   var ws_manager = new TransportManager({
+    transportType: 'ws',
     lives: config.wsLives,
     minPingDelay: 10000,
-    maxPingDelay: config.activityTimeout
+    maxPingDelay: config.activityTimeout,
+    reportDeathCallback: config.reportDeathCallback
   });
   var streaming_manager = new TransportManager({
+    transportType: 'streaming',
     lives: 2,
     minPingDelay: 10000,
-    maxPingDelay: config.activityTimeout
+    maxPingDelay: config.activityTimeout,
+    reportDeathCallback: config.reportDeathCallback
   });
 
   var ws_transport = defineTransportStrategy(

--- a/src/runtimes/web/default_strategy.ts
+++ b/src/runtimes/web/default_strategy.ts
@@ -67,7 +67,7 @@ var getDefaultStrategy = function(
   };
 
   var ws_manager = new TransportManager({
-    lives: 2,
+    lives: config.wsLives,
     minPingDelay: 10000,
     maxPingDelay: config.activityTimeout
   });

--- a/types/src/core/config.d.ts
+++ b/types/src/core/config.d.ts
@@ -18,6 +18,7 @@ export interface Config {
     wsPath: string;
     wsPort: number;
     wssPort: number;
+    wsLives: number;
     userAuthenticator: UserAuthenticationHandler;
     channelAuthorizer: ChannelAuthorizationHandler;
     forceTLS?: boolean;

--- a/types/src/core/config.d.ts
+++ b/types/src/core/config.d.ts
@@ -28,5 +28,6 @@ export interface Config {
     ignoreNullOrigin?: boolean;
     nacl?: nacl;
     timelineParams?: any;
+    reportDeathCallback?: (info: Object) => void;
 }
 export declare function getConfig(opts: Options, pusher: any): Config;

--- a/types/src/core/defaults.d.ts
+++ b/types/src/core/defaults.d.ts
@@ -6,6 +6,7 @@ export interface DefaultConfig {
     wsPort: number;
     wssPort: number;
     wsPath: string;
+    wsLives: number;
     httpHost: string;
     httpPort: number;
     httpsPort: number;

--- a/types/src/core/options.d.ts
+++ b/types/src/core/options.d.ts
@@ -31,5 +31,6 @@ export interface Options {
     wsPort?: number;
     wssPort?: number;
     wsLives?: number;
+    reportDeathCallback?: (info: Object) => void;
 }
 export declare function validateOptions(options: any): void;

--- a/types/src/core/options.d.ts
+++ b/types/src/core/options.d.ts
@@ -30,5 +30,6 @@ export interface Options {
     wsPath?: string;
     wsPort?: number;
     wssPort?: number;
+    wsLives?: number;
 }
 export declare function validateOptions(options: any): void;

--- a/types/src/core/transports/transport_manager.d.ts
+++ b/types/src/core/transports/transport_manager.d.ts
@@ -3,12 +3,15 @@ import Transport from './transport';
 import PingDelayOptions from './ping_delay_options';
 export interface TransportManagerOptions extends PingDelayOptions {
     lives?: number;
+    transportType?: string;
+    reportDeathCallback?: (info: Object) => void;
 }
 export default class TransportManager {
     options: TransportManagerOptions;
     livesLeft: number;
+    reportDeathCallback?: (info: Object) => void;
     constructor(options: TransportManagerOptions);
     getAssistant(transport: Transport): AssistantToTheTransportManager;
     isAlive(): boolean;
-    reportDeath(): void;
+    reportDeath(info?: Object): void;
 }

--- a/webpack/hosting_config.js
+++ b/webpack/hosting_config.js
@@ -1,5 +1,7 @@
+const officialPusherJSVersion = '8.0.1';
+
 module.exports = {
-  version: process.env.VERSION || require('../package').version,
+  version: officialPusherJSVersion,
   cdn_http: process.env.CDN_HTTP || 'http://js.pusher.com',
   cdn_https: process.env.CDN_HTTPS || 'https://js.pusher.com',
   dependency_suffix: process.env.MINIFY ? '.min' : ''


### PR DESCRIPTION
## What does this PR do?

This PR adds a couple of changes for us to be able to test using WebSockets as the only transport mechanism without risk of falling into the unrecoverable "failed" state, and to gather more information about why and how often the connections drop to the fallback transport.

This change will more than likely not make it back into the official pusher-js repo, it's just meant for us to quickly test. As such, we should not merge this PR – it's just here for reviewing. Depending on what we find, a more flushed out change may come later.

## Checklist

- [ ] All new functionality has tests.
- [x] All tests are passing.
- [ ] New or changed API methods have been documented.
- [x] `npm run format` has been run

## CHANGELOG

- [CHANGED] made WebSocket lives configurable for the user
- [ADDED] optional reportDeathCallback to allow users to get information about why a transport mechanism lost a life
- [CHANGED] changed name of package to @goguardian/pusher-js

